### PR TITLE
feat(logo): usar logo em SVG no header/drawer/footer

### DIFF
--- a/public/images/logo-achadocerto.svg
+++ b/public/images/logo-achadocerto.svg
@@ -1,26 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 300" width="1200" height="300">
-  <!-- Background -->
-  <rect width="1200" height="300" fill="white" opacity="0"/>
-  
-  <!-- "Achad" text in bold navy-blue -->
-  <text x="40" y="155" font-family="Arial, sans-serif" font-size="130" font-weight="bold" fill="#142864" letter-spacing="-2">
-    Achad
-  </text>
-  
-  <!-- Magnifying glass replacing "O" -->
-  <circle cx="240" cy="125" r="40" fill="none" stroke="#1F90FF" stroke-width="9"/>
-  <line x1="268" y1="153" x2="340" y2="225" stroke="#1F90FF" stroke-width="9" stroke-linecap="round"/>
-  
-  <!-- "Certo" text in regular navy-blue -->
-  <text x="360" y="155" font-family="Arial, sans-serif" font-size="125" font-weight="normal" fill="#142864" letter-spacing="-2">
-    Certo
-  </text>
-  
-  <!-- VIP Badge with GOLD text -->
-  <rect x="815" y="85" width="95" height="70" rx="12" ry="12" fill="#142864" stroke="#D4AF37" stroke-width="3"/>
-  
-  <!-- VIP text in GOLD - much better contrast -->
-  <text x="862" y="135" font-family="Arial, sans-serif" font-size="35" font-weight="bold" fill="#D4AF37" text-anchor="middle">
-    VIP
-  </text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 120" role="img" aria-label="AchadoCerto">
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0" stop-color="#111827"/>
+      <stop offset="1" stop-color="#2563EB"/>
+    </linearGradient>
+  </defs>
+  <rect width="520" height="120" rx="18" fill="white"/>
+  <g transform="translate(24,26)">
+    <circle cx="34" cy="34" r="34" fill="url(#g)"/>
+    <path d="M27 51l9-26 9 26" fill="none" stroke="#fff" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M24 38h24" fill="none" stroke="#fff" stroke-width="6" stroke-linecap="round"/>
+  </g>
+  <g font-family="Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial" font-size="54" font-weight="800" transform="translate(98,76)">
+    <text x="0" y="0" fill="#111827">Achado</text>
+    <text x="190" y="0" fill="#2563EB">Certo</text>
+  </g>
 </svg>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -100,7 +100,9 @@ const schemaData = JSON.stringify(schema ?? defaultSchema);
   <!-- DRAWER MOBILE -->
   <aside class="drawer" id="drawer" role="dialog" aria-label="Menu" aria-hidden="true">
     <div class="drawer-header">
-      <span class="logo">Achado<span class="logo-accent">Certo</span></span>
+      <a href="/" class="brand" aria-label="AchadoCerto (Início)">
+        <img src="/images/logo-achadocerto.svg" width="160" height="37" alt="AchadoCerto" loading="lazy" decoding="async" />
+      </a>
       <button class="drawer-close" onclick="window.closeDrawer()" aria-label="Fechar menu">
         <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
       </button>
@@ -148,7 +150,9 @@ const schemaData = JSON.stringify(schema ?? defaultSchema);
         </button>
 
         <!-- Logo -->
-        <a href="/" class="logo">Achado<span class="logo-accent">Certo</span></a>
+        <a href="/" class="brand" aria-label="AchadoCerto (Início)">
+          <img src="/images/logo-achadocerto.svg" width="170" height="39" alt="AchadoCerto" decoding="async" fetchpriority="high" />
+        </a>
 
         <!-- Search desktop -->
         <form class="header-search" role="search" action="/blog" method="get">
@@ -192,7 +196,9 @@ const schemaData = JSON.stringify(schema ?? defaultSchema);
     <div class="container">
       <div class="footer-grid">
         <div>
-          <a href="/" class="footer-logo logo">Achado<span class="logo-accent">Certo</span></a>
+          <a href="/" class="footer-logo brand" aria-label="AchadoCerto (Início)">
+            <img src="/images/logo-achadocerto.svg" width="170" height="39" alt="AchadoCerto" loading="lazy" decoding="async" />
+          </a>
           <p class="footer-desc">Reviews independentes, comparativos honestos e guias de compra para você escolher com confiança.</p>
           <div class="footer-social">
             <a href="https://x.com/achadocerto" target="_blank" rel="noopener noreferrer" aria-label="X (Twitter)" class="social-btn social-x">
@@ -251,26 +257,12 @@ const schemaData = JSON.stringify(schema ?? defaultSchema);
     .social-x         { background:#000; }
     .social-whatsapp  { background:#25D366; }
     .social-instagram { background:radial-gradient(circle at 30% 107%,#fdf497 0%,#fdf497 5%,#fd5949 45%,#d6249f 60%,#285AEB 90%); }
-    .footer-shop-link {
-      display: flex;
-      align-items: center;
-      gap: 7px;
-      font-size: 14px;
-      color: var(--c-text-sub);
-      transition: color .2s;
-      padding: 3px 0;
-    }
-    .footer-shop-link:hover { color: var(--c-brand); }
-    .footer-shop-badge {
-      font-size: 10px;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: .4px;
-      color: var(--c-brand);
-      background: var(--c-brand-soft, #EBF2FF);
-      padding: 1px 6px;
-      border-radius: 20px;
-      margin-left: 2px;
+
+    .brand { display:inline-flex; align-items:center; }
+    .brand img { display:block; height:auto; }
+
+    @media (max-width: 520px) {
+      .brand img { width: 140px; height: auto; }
     }
   </style>
 


### PR DESCRIPTION
Troca o logo textual por um logo em SVG (arquivo em `public/images/logo-achadocerto.svg`) e aplica de forma consistente no header, drawer mobile e footer.

- Header: usa `<a class="brand">` com `<img ... fetchpriority="high">`
- Drawer: usa o mesmo SVG
- Footer: usa o mesmo SVG

Isso elimina a inconsistência do logo e facilita futuras trocas do arquivo sem mexer no layout.
